### PR TITLE
replace `zlib` by the command line tool `gunzip`

### DIFF
--- a/speechcolab/datasets/gigaspeech.py
+++ b/speechcolab/datasets/gigaspeech.py
@@ -9,7 +9,7 @@ import ijson
 import yaml
 from Crypto.Cipher import AES
 
-from speechcolab.utils.download import download, file_md5
+from speechcolab.utils.download import download, file_md5, string_md5
 
 url_of_host = {
     'oss': 'oss://speechcolab/GigaSpeech/release/GigaSpeech',
@@ -56,6 +56,7 @@ class GigaSpeech(object):
             raise NotImplementedError('For downloading from OSS, please use: '
                                       'github.com/SpeechColab/GigaSpeech/blob/main/utils/download_gigaspeech.sh')
 
+        assert string_md5(password) == 'a2932ace6e301f5ae6c48c13007a6b32', f'Invalid Password.'
         self.password = password
 
         # User agreement

--- a/speechcolab/datasets/gigaspeech.py
+++ b/speechcolab/datasets/gigaspeech.py
@@ -1,8 +1,7 @@
-import io
+import os
 import re
 import tarfile
 import time
-import zlib
 from hashlib import pbkdf2_hmac
 from pathlib import Path
 
@@ -157,14 +156,7 @@ class GigaSpeech(object):
                 tar.extractall(path=subdir)
         elif local_obj_dec.suffix == '.gz':
             # encripted-gziped object represents a regular GigaSpeech file
-            out_path = local_obj_dec.parent / Path(local_obj_dec.stem.strip('.gz'))
-            z = zlib.decompressobj(zlib.MAX_WBITS | 16)
-            with open(local_obj_dec, 'rb') as f_in, open(out_path, 'wb') as f_out:
-                while True:
-                    chunk = f_in.read(self.chunk_size)
-                    if not chunk:
-                        break
-                    f_out.write(z.decompress(chunk))
+            os.system(f'gunzip {local_obj_dec}')
         else:
             # keep the object as it is
             pass

--- a/speechcolab/utils/download.py
+++ b/speechcolab/utils/download.py
@@ -59,3 +59,7 @@ def file_md5(filename, chunk_size=40960):
                 break
             filehash.update(chunk)
     return filehash.hexdigest()
+
+
+def string_md5(text):
+    return hashlib.md5(text.encode()).hexdigest()


### PR DESCRIPTION
For the issue (https://github.com/SpeechColab/GigaSpeech/issues/93) reporting decompress fail, we use the command line tool `gunzip`, which might be ugly but safe, instead of Python's `zlib` package.